### PR TITLE
Support IPv6

### DIFF
--- a/dnsgrab_test.go
+++ b/dnsgrab_test.go
@@ -43,7 +43,7 @@ func TestPersistent(t *testing.T) {
 }
 
 func doTest(t *testing.T, cache Cache, startingIP uint32) {
-	s, err := ListenWithCache(":0", "8.8.8.8", cache)
+	s, err := ListenWithCache(":0", func() string { return "8.8.8.8" }, cache)
 	require.NoError(t, err)
 	defer s.Close()
 	go s.Serve()


### PR DESCRIPTION
When client is running on an IPv6 network, it will issue queries for DNS AAAA records rather than A records. We need to handle that, which this PR does.

One thing that's a bit goofy is that we're returning IPv4 addresses for the AAAA queries, but since these are fake addresses that we just reverse back into the hostname anyway, it doesn't seem to matter in practice.

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?