### PR TITLE
Ignore empty A and AAAA name queries

### DIFF
--- a/dnsgrab_test.go
+++ b/dnsgrab_test.go
@@ -76,6 +76,14 @@ func doTest(t *testing.T, cache Cache, startingIP uint32) {
 		require.Equal(t, name, reversed, "Wrong reverse lookup for '%v'", condition)
 	}
 
+	testError := func(name string) {
+		q := &dns.Msg{}
+		q.SetQuestion(name+".", dns.TypeA)
+
+		_, err := dns.Exchange(q, addr)
+		require.Error(t, err)
+	}
+
 	testUnknown := func(name string, succeed bool, ip string, condition string) {
 		reversed, ok := s.ReverseLookup(net.ParseIP(ip))
 		require.Equal(t, succeed, ok, "Unexpected reverse lookup status for '%v'", condition)
@@ -88,6 +96,7 @@ func doTest(t *testing.T, cache Cache, startingIP uint32) {
 	test("domain3", startingIP+2, "third query, new IP")
 	time.Sleep(maxAge)
 	test("domain2", startingIP+3, "repeated expired query, new IP")
+	testError("")
 
 	testUnknown("172.155.98.32", true, "172.155.98.32", "regular IP address")
 	testUnknown("", false, "240.0.10.10", "unknown fake IP address")


### PR DESCRIPTION
For getlantern/android-lantern#336

In the wild, we sometimes get DNS queries with a blank name. That causes a panic in our caching layer. The change is to just ignore these names and pass the DNS queries on up the chain.

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?